### PR TITLE
Add Sonos Group Discovery Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,28 @@ Adjust volume steps with `?value=10` parameter, without this default functionali
 ## Credit
 
 Cheers to Avi Miller for the REST endpoints inspiration!
+
+## Configuration
+
+This plugin is configured through the Homebridge user interface or by editing the config.json file directly.
+
+### Options
+
+- **Separate Switch For Mute**: Creates a separate switch to control mute. (Default: true)
+- **Only offer controls for soundbars**: Restricts the plugin to only control Sonos soundbars (Beam, Arc, Playbar, Ray). (Default: false)
+- **Use the room name as the device name**: Uses the Sonos room name as the HomeKit device name. (Default: false)
+- **Sonos Group Discovery Mode**: Controls how Sonos groups are discovered and presented in HomeKit. (Default: auto)
+  - **Auto - Smart Group Detection**: Only shows groups with multiple devices
+  - **Individual Devices Only**: Only shows individual Sonos devices, regardless of grouping
+  - **Groups Only**: Only shows Sonos groups
+  - **Both Individual Devices and Groups**: Shows both individual devices and their groups
+- **Format for Group Names**: Controls how group names are displayed. (Default: coordinator_plus)
+  - **Coordinator Room with Count**: Shows format like "Living Room (2)"
+  - **Group Members**: Shows all members like "Living Room, Kitchen, Office"
+  - **Simple Group Name**: Shows a simple format like "Sonos Group Living Room"
+- **Volume Options**: Choose how to control volume. (Default: none)
+  - **None**: No volume control
+  - **Lightbulb**: Use a lightbulb control for volume
+  - **Fan**: Use a fan control for volume
+- **Offer API endpoints to control your devices**: Creates HTTP endpoints for external control. (Default: false)
+- **Preserve volume for each input**: Remembers separate volume levels for different inputs. (Default: false)

--- a/config.schema.json
+++ b/config.schema.json
@@ -20,6 +20,29 @@
                 "type": "boolean",
                 "default": false
             },
+            "groupDiscoveryMode": {
+                "title": "Sonos Group Discovery Mode",
+                "type": "string",
+                "default": "auto",
+                "oneOf": [
+                    { "title": "Auto - Smart Group Detection", "enum": ["auto"] },
+                    { "title": "Individual Devices Only", "enum": ["individual"] },
+                    { "title": "Groups Only", "enum": ["groups"] },
+                    { "title": "Both Individual Devices and Groups", "enum": ["both"] }
+                ],
+                "required": true
+            },
+            "groupNamingFormat": {
+                "title": "Format for Group Names",
+                "type": "string",
+                "default": "coordinator_plus",
+                "oneOf": [
+                    { "title": "Coordinator Room with Count (Living Room (2))", "enum": ["coordinator_plus"] },
+                    { "title": "Group Members (Living Room, Kitchen, Office)", "enum": ["members_list"] },
+                    { "title": "Simple Group Name (Sonos Group Living Room)", "enum": ["simple"] }
+                ],
+                "required": true
+            },
             "volume": {
                 "title": "Volume Options",
                 "type": "string",

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -19,6 +19,12 @@ export type DeviceDetails = {
     ExpressAppPort: number;
     AudioInputVolumes: AudioInputModel[];
     UpdateAudioVolumes: (uuid: string, currentSettings: AudioInputModel, currentSavedSettings: AudioInputModel[]) => void;
+    IsGroup?: boolean;
+    IsCoordinator?: boolean;
+    IsHomeTheater?: boolean;
+    GroupID?: string;
+    GroupName?: string;
+    GroupMembers?: string[];
 };
 
 export type AudioInputModel = {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -2,11 +2,31 @@ import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig }
 import { BREAKING_CHANGE_PACKAGE_VERSION, PLATFORM_NAME, PLUGIN_NAME, SOUNDBAR_NAMES, DEFAULT_EXPRESS_PORT } from './models/constants';
 import { SonosPlatformAccessory } from './platformAccessory';
 import { AsyncDeviceDiscovery } from 'sonos';
-import { Device } from './models/sonos-types';
+import { Device, Group, ZoneGroupMember } from './models/sonos-types';
 import express from 'express';
 import detect from 'detect-port';
 import { FoundDevices, DeviceDetails, AudioInputModel, ExpressModel } from './models/models';
 import helmet from 'helmet';
+
+interface DeviceInfo {
+    device: Device;
+    description: any;
+    uuid: string;
+    roomName: string;
+    modelName: string;
+    configuration: string;
+    isSoundbar: boolean;
+    isSub: boolean;
+    isSatellite: boolean;
+    roomPrefix: string;
+}
+
+interface HomeTheaterSystem {
+    roomName: string;
+    soundbar: DeviceInfo;
+    satellites: DeviceInfo[];
+    subs: DeviceInfo[];
+}
 
 /**
  * HomebridgePlatform
@@ -65,8 +85,93 @@ export class SonosPlatform implements DynamicPlatformPlugin {
             return;
         }
 
-        this.coordinators = (await sonosDevices[0].getAllGroups()).map((x) => x.CoordinatorDevice().host);
+        this.log.info(`Discovered ${sonosDevices.length} Sonos devices`);
 
+        // Get all groups information
+        const groups = await sonosDevices[0].getAllGroups();
+        this.log.info(`Discovered ${groups.length} Sonos groups`);
+
+        // Get discovery mode from config (default to 'auto' if not specified)
+        const discoveryMode = this.config.groupDiscoveryMode || 'auto';
+        this.log.info(`Group discovery mode: ${discoveryMode}`);
+
+        // Log all discovered groups at the start for easier debugging
+        this.logSonosGroups(groups);
+
+        // Get detailed information about each device
+        const deviceInfos = await this.getDeviceDetails(sonosDevices, groups);
+
+        // Find home theater systems by analyzing device information
+        const homeTheaterSystems = this.detectHomeTheaterSystems(deviceInfos);
+
+        // Devices to skip in individual device processing (part of multi-member groups)
+        const devicesInGroups = new Set<string>();
+
+        // Process home theater systems
+        for (const system of homeTheaterSystems) {
+            const allDevices = [system.soundbar, ...system.satellites, ...system.subs];
+
+            // Mark all these devices as being in a group
+            allDevices.forEach((info) => devicesInGroups.add(info.uuid));
+
+            // Create and register the home theater group
+            await this.createHomeTheaterGroup(system);
+        }
+
+        // Process multi-room groups
+        if (discoveryMode === 'auto' || discoveryMode === 'groups' || discoveryMode === 'both') {
+            for (const group of groups) {
+                // Skip single-member groups in auto mode
+                if (discoveryMode === 'auto' && group.ZoneGroupMember.length <= 1) {
+                    continue;
+                }
+
+                // Skip groups where all members are part of a home theater setup
+                const allMembersInHomeTheater = group.ZoneGroupMember.every((member) => devicesInGroups.has(member.UUID));
+
+                if (allMembersInHomeTheater) {
+                    continue;
+                }
+
+                // For multi-member groups, add all members to the group tracking set
+                if (group.ZoneGroupMember.length > 1) {
+                    group.ZoneGroupMember.forEach((member) => devicesInGroups.add(member.UUID));
+                }
+
+                // Find the coordinator device
+                const coordinatorDevice = sonosDevices.find((device) => device.host === group.host);
+                if (!coordinatorDevice) {
+                    this.log.warn(`Couldn't find coordinator device for group ${group.Name}`);
+                    continue;
+                }
+
+                await this.registerDiscoveredGroup(coordinatorDevice, group);
+            }
+        }
+
+        // Process individual devices
+        if (discoveryMode === 'individual' || discoveryMode === 'both' || discoveryMode === 'auto') {
+            for (const device of sonosDevices) {
+                // Get device UUID from its description
+                const description = await device.deviceDescription();
+                const deviceUuid = description.UDN.replace('uuid:', '');
+
+                // In auto mode, skip individual devices that are part of multi-member groups or home theater
+                if (discoveryMode === 'auto' && devicesInGroups.has(deviceUuid)) {
+                    this.log.debug(`Skipping individual device ${description.roomName} as it's part of a multi-device group or home theater`);
+                    continue;
+                }
+
+                // Identify if this device is a coordinator
+                const isCoordinator = groups.some((group) =>
+                    group.ZoneGroupMember.some((member) => member.UUID.includes(group.Coordinator) && device.host === group.host)
+                );
+
+                await this.registerDiscoveredDevice(device, isCoordinator);
+            }
+        }
+
+        // Set up express app if needed
         if (this.config.volumeControlEndpoints) {
             try {
                 this.expressDetails = await this.setupExpressApp();
@@ -76,14 +181,9 @@ export class SonosPlatform implements DynamicPlatformPlugin {
             }
         }
 
-        //This is done this way for a reason, the .forEach doesn't await as each iteration has it's own func generation so doesn't know to wait for the others
-        //Basically just don't refactor this thinking you're smart Brian. I see you.
-        for (let device of sonosDevices) {
-            await this.registerDiscoveredDevices(device);
-        }
-
         this.removeDevicesNotDiscovered();
 
+        // Configure express app routes
         if (this.accessories.length > 1 && this.expressDetails) {
             // 404 handler
             this.expressDetails.app.use((req, res, next) => {
@@ -104,39 +204,209 @@ export class SonosPlatform implements DynamicPlatformPlugin {
         }
     }
 
-    async registerDiscoveredDevices(device: Device) {
-        if (!this.coordinators.includes(device.host)) return;
+    // Log all discovered Sonos groups for debugging
+    private logSonosGroups(groups: Group[]): void {
+        this.log.info('=== SONOS GROUP STRUCTURE ===');
+        groups.forEach((group, index) => {
+            const memberCount = group.ZoneGroupMember.length;
+            const coordinator = group.ZoneGroupMember.find((m) => m.UUID.includes(group.Coordinator));
+            const coordinatorName = coordinator ? coordinator.ZoneName : 'Unknown';
 
-        let description = await device.deviceDescription();
+            this.log.info(
+                `Group ${index + 1}/${groups.length}: Coordinator: ${coordinatorName} [${memberCount} member${memberCount !== 1 ? 's' : ''}]`
+            );
+
+            // Check for special group types
+            const hasHomeTheaterIndicators = group.ZoneGroupMember.some(
+                (m) =>
+                    m.Configuration &&
+                    (m.Configuration.includes('HT') || m.Configuration.includes('BONDED') || m.Configuration.includes('SATELLITES'))
+            );
+
+            const groupType = hasHomeTheaterIndicators ? 'HOME THEATER' : memberCount > 1 ? 'MULTI-ROOM' : 'STANDALONE';
+
+            this.log.info(`  Type: ${groupType}`);
+
+            // List all members with their configurations
+            group.ZoneGroupMember.forEach((member, i) => {
+                const isCoordinator = member.UUID.includes(group.Coordinator);
+                const role = isCoordinator ? '[COORDINATOR]' : '';
+                const config = member.Configuration ? this.getDeviceRole(member.Configuration) : '';
+
+                this.log.info(`  ${i + 1}. ${member.ZoneName} ${role} ${config}`);
+            });
+
+            this.log.info('--------------------------');
+        });
+    }
+
+    // Collect detailed information about all devices
+    private async getDeviceDetails(sonosDevices: Device[], groups: Group[]): Promise<DeviceInfo[]> {
+        const deviceInfos: DeviceInfo[] = [];
+
+        for (const device of sonosDevices) {
+            const desc = await device.deviceDescription();
+            const uuid = desc.UDN.replace('uuid:', '');
+
+            // Find configuration from groups data
+            let configuration = '';
+            for (const group of groups) {
+                const member = group.ZoneGroupMember.find((m) => m.UUID === uuid);
+                if (member && member.Configuration) {
+                    configuration = member.Configuration;
+                    break;
+                }
+            }
+
+            // Extract the base room name without device type suffixes
+            const roomPrefix = desc.roomName.replace(/\s+(Sonos|One SL|Sub|Beam|Arc|Ray|Playbar|Playbase).*$/i, '').trim();
+
+            // Identify device types
+            const isSoundbar = SOUNDBAR_NAMES.some(
+                (name) =>
+                    desc.modelName.toUpperCase().includes(name) ||
+                    (configuration && (configuration.toUpperCase().includes(name) || configuration.includes('HT')))
+            );
+
+            const isSub =
+                desc.modelName.toUpperCase().includes('SUB') ||
+                desc.roomName.toUpperCase().includes('SUB') ||
+                (configuration ? configuration.includes('SUB') : false);
+
+            const isSatellite =
+                desc.modelName.toUpperCase().includes('ONE') ||
+                desc.roomName.toUpperCase().includes('ONE SL') ||
+                (configuration ? configuration.includes('SATELLITE') || configuration.includes('LEFT') || configuration.includes('RIGHT') : false);
+
+            deviceInfos.push({
+                device,
+                description: desc,
+                uuid,
+                roomName: desc.roomName,
+                modelName: desc.modelName,
+                configuration,
+                isSoundbar,
+                isSub,
+                isSatellite,
+                roomPrefix
+            });
+        }
+
+        return deviceInfos;
+    }
+
+    // Detect home theater systems by analyzing device relationships
+    private detectHomeTheaterSystems(deviceInfos: DeviceInfo[]): HomeTheaterSystem[] {
+        const homeTheaterSystems: HomeTheaterSystem[] = [];
+
+        // Group devices by room prefix
+        const devicesByRoom = new Map<string, DeviceInfo[]>();
+        deviceInfos.forEach((info) => {
+            if (!devicesByRoom.has(info.roomPrefix)) {
+                devicesByRoom.set(info.roomPrefix, []);
+            }
+            devicesByRoom.get(info.roomPrefix)?.push(info);
+        });
+
+        // Analyze each room for home theater components
+        devicesByRoom.forEach((devices, roomPrefix) => {
+            if (devices.length < 2) return; // Need at least 2 devices for a home theater
+
+            this.log.debug(`Analyzing room "${roomPrefix}" with ${devices.length} devices for home theater components`);
+
+            // Find soundbar
+            const soundbar = devices.find((d) => d.isSoundbar);
+            if (!soundbar) return;
+
+            // Find satellites and subwoofers
+            const satellites = devices.filter((d) => d.isSatellite);
+            const subs = devices.filter((d) => d.isSub);
+
+            // If we have a soundbar and either satellites or subs, we have a home theater
+            if (satellites.length > 0 || subs.length > 0) {
+                this.log.info(`Detected home theater system in "${roomPrefix}" with:
+  - Soundbar: ${soundbar.roomName}
+  - Satellites: ${satellites.map((s) => s.roomName).join(', ') || 'None'}
+  - Subwoofer: ${subs.map((s) => s.roomName).join(', ') || 'None'}`);
+
+                homeTheaterSystems.push({
+                    roomName: roomPrefix,
+                    soundbar,
+                    satellites,
+                    subs
+                });
+            }
+        });
+
+        return homeTheaterSystems;
+    }
+
+    // Create and register a home theater group
+    private async createHomeTheaterGroup(system: HomeTheaterSystem): Promise<void> {
+        const { roomName, soundbar, satellites, subs } = system;
+        const allDevices = [soundbar, ...satellites, ...subs];
+
+        // Create a synthetic group for this home theater
+        const homeTheaterGroup: Group = {
+            Coordinator: soundbar.uuid,
+            ID: `hometheater-${roomName.replace(/\s+/g, '-')}`,
+            ZoneGroupMember: allDevices.map(
+                (d) =>
+                    ({
+                        UUID: d.uuid,
+                        ZoneName: d.roomName,
+                        Configuration: d.configuration
+                    }) as ZoneGroupMember
+            ),
+            Name: `${roomName} Home Theater`,
+            host: soundbar.device.host,
+            port: soundbar.device.port,
+            CoordinatorDevice: () => soundbar.device
+        };
+
+        this.log.info(`Created home theater group for ${roomName} with ${allDevices.length} components`);
+
+        // Register the home theater group
+        await this.registerDiscoveredHomeTheater(soundbar.device, homeTheaterGroup);
+    }
+
+    async registerDiscoveredDevice(sonosDevice: Device, isCoordinator: boolean) {
+        let description = await sonosDevice.deviceDescription();
         let displayNameUpperCase = description.displayName.toUpperCase();
         let IsSoundBar = SOUNDBAR_NAMES.includes(displayNameUpperCase);
 
         if (this.config.soundbarsOnly && !IsSoundBar) return;
 
+        // Use room or device name based on config
         let deviceDisplayName = this.config.roomNameAsName ? description.roomName : description.displayName;
 
+        // Create a unique ID for the device based on MAC
         const uuid = this.api.hap.uuid.generate(`${description.MACAddress}:${BREAKING_CHANGE_PACKAGE_VERSION}`);
         this.foundDevices.push({ uuid: uuid, name: deviceDisplayName });
-        this.log.debug(`Found device - UUID is : ${uuid}`);
+
+        this.log.debug(`Found device - UUID: ${uuid}, Name: ${deviceDisplayName}, Coordinator: ${isCoordinator}`);
+
         const existingAccessory = this.accessories.find((accessory) => accessory.UUID === uuid);
 
         const deviceDetailsModel = {
             UUID: uuid,
-            Host: device.host,
+            Host: sonosDevice.host,
             IsSoundBar: IsSoundBar,
             Manufacturer: description.manufacturer,
             SerialNumber: description.serialNum,
             ModelName: description.modelName,
             FirmwareVersion: description.softwareVersion,
             RoomName: description.roomName,
-            DisplayName: description.displayName,
+            DisplayName: deviceDisplayName,
             ExpressAppPort: this.expressAppPort,
             AudioInputVolumes: [],
-            UpdateAudioVolumes: this.updateInputVolumeLevels.bind(this)
+            UpdateAudioVolumes: this.updateInputVolumeLevels.bind(this),
+            IsGroup: false,
+            IsCoordinator: isCoordinator
         } as DeviceDetails;
 
         if (existingAccessory) {
-            this.log.info(`Adding ${description.roomName} ${description.displayName} from cache`);
+            this.log.info(`Adding device ${deviceDisplayName} from cache`);
             existingAccessory.displayName = deviceDisplayName;
             deviceDetailsModel.AudioInputVolumes = existingAccessory.context.device.AudioInputVolumes;
             existingAccessory.context.device = deviceDetailsModel;
@@ -148,7 +418,216 @@ export class SonosPlatform implements DynamicPlatformPlugin {
             return;
         }
 
-        this.log.info(`Adding ${description.roomName} ${description.displayName} as new device`);
+        this.log.info(`Adding device ${deviceDisplayName} as new device`);
+        const accessory = new this.api.platformAccessory(deviceDisplayName, uuid);
+        accessory.context.device = deviceDetailsModel;
+        new SonosPlatformAccessory(this, accessory, this.expressDetails);
+
+        this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+    }
+
+    async registerDiscoveredGroup(coordinatorDevice: Device, group: Group) {
+        let description = await coordinatorDevice.deviceDescription();
+        let displayNameUpperCase = description.displayName.toUpperCase();
+        let IsSoundBar = SOUNDBAR_NAMES.includes(displayNameUpperCase);
+
+        if (this.config.soundbarsOnly && !IsSoundBar) {
+            this.log.debug(`Skipping non-soundbar group: ${group.Name}`);
+            return;
+        }
+
+        // For groups, use the group name based on configuration
+        let groupName = '';
+        let isGrouped = group.ZoneGroupMember.length > 1;
+        const groupNamingFormat = this.config.groupNamingFormat || 'coordinator_plus';
+
+        // Check if this is likely a home theater setup
+        const isHomeTheater = group.ZoneGroupMember.some(
+            (member) =>
+                member.Configuration &&
+                (member.Configuration.includes('HT') || member.Configuration.includes('BONDED') || member.Configuration.includes('SATELLITES'))
+        );
+
+        // Number of surround speakers
+        const possibleSurrounds = group.ZoneGroupMember.length >= 3;
+        const homeTheaterSetup = isHomeTheater || (possibleSurrounds && IsSoundBar);
+
+        // If there are multiple devices in the group
+        if (isGrouped) {
+            const coordinatorMember = group.ZoneGroupMember.find((member) => member.UUID.includes(group.Coordinator));
+            const coordinatorZoneName = coordinatorMember?.ZoneName || description.roomName;
+
+            // Special naming for home theater setups
+            if (homeTheaterSetup) {
+                groupName = `${coordinatorZoneName} Home Theater`;
+                this.log.info(`Creating home theater accessory: "${groupName}"`);
+
+                // List the components of the home theater setup
+                this.log.debug('Home theater components:');
+                group.ZoneGroupMember.forEach((member, i) => {
+                    const role = this.getDeviceRole(member.Configuration || '');
+                    const isCoord = member.UUID.includes(group.Coordinator) ? ' (coordinator)' : '';
+                    this.log.debug(`  ${i + 1}. ${member.ZoneName}${isCoord} ${role}`);
+                });
+            } else {
+                switch (groupNamingFormat) {
+                    case 'coordinator_plus':
+                        // Format: "Living Room (2)"
+                        groupName = `${coordinatorZoneName} (${group.ZoneGroupMember.length - 1})`;
+                        break;
+
+                    case 'members_list':
+                        // Format: "Living Room, Kitchen, Office"
+                        groupName = group.ZoneGroupMember.map((m) => m.ZoneName).join(', ');
+                        break;
+
+                    case 'simple':
+                        // Format: "Sonos Group Living Room"
+                        groupName = `Sonos Group ${coordinatorZoneName}`;
+                        break;
+
+                    default:
+                        // Default fallback
+                        groupName = `${coordinatorZoneName} Group`;
+                }
+                this.log.info(`Creating group accessory: "${groupName}" with format ${groupNamingFormat}`);
+
+                // List the members of the group
+                this.log.debug('Group members:');
+                group.ZoneGroupMember.forEach((member, i) => {
+                    const isCoord = member.UUID.includes(group.Coordinator) ? ' (coordinator)' : '';
+                    this.log.debug(`  ${i + 1}. ${member.ZoneName}${isCoord}`);
+                });
+            }
+        } else {
+            // Single device group - use its zone name
+            groupName = group.ZoneGroupMember[0].ZoneName || description.roomName;
+            this.log.info(`Creating single device group: "${groupName}"`);
+        }
+
+        // Use configured preference for display name
+        let deviceDisplayName = this.config.roomNameAsName ? groupName : isGrouped ? groupName : description.displayName;
+
+        // Create a unique ID for the group based on coordinator MAC plus group ID
+        const uuid = this.api.hap.uuid.generate(`${description.MACAddress}:${group.ID}:${BREAKING_CHANGE_PACKAGE_VERSION}`);
+        this.foundDevices.push({ uuid: uuid, name: deviceDisplayName });
+
+        this.log.debug(`HomeKit accessory - UUID: ${uuid}, Name: "${deviceDisplayName}"`);
+
+        if (homeTheaterSetup) {
+            this.log.debug(`Home theater hardware: ${description.modelName} (${description.displayName})`);
+        }
+
+        const existingAccessory = this.accessories.find((accessory) => accessory.UUID === uuid);
+
+        const deviceDetailsModel = {
+            UUID: uuid,
+            Host: coordinatorDevice.host,
+            IsSoundBar: IsSoundBar,
+            Manufacturer: description.manufacturer,
+            SerialNumber: description.serialNum,
+            ModelName: description.modelName,
+            FirmwareVersion: description.softwareVersion,
+            RoomName: groupName,
+            DisplayName: deviceDisplayName,
+            ExpressAppPort: this.expressAppPort,
+            AudioInputVolumes: [],
+            UpdateAudioVolumes: this.updateInputVolumeLevels.bind(this),
+            // Group-related info
+            IsGroup: isGrouped,
+            IsHomeTheater: homeTheaterSetup,
+            GroupID: group.ID,
+            GroupName: groupName,
+            GroupMembers: group.ZoneGroupMember.map((m) => m.ZoneName)
+        } as DeviceDetails;
+
+        if (existingAccessory) {
+            this.log.info(`Updating group "${deviceDisplayName}" from cache`);
+            existingAccessory.displayName = deviceDisplayName;
+            deviceDetailsModel.AudioInputVolumes = existingAccessory.context.device.AudioInputVolumes;
+            existingAccessory.context.device = deviceDetailsModel;
+            new SonosPlatformAccessory(this, existingAccessory, this.expressDetails);
+
+            this.api.updatePlatformAccessories([existingAccessory]);
+            return;
+        }
+
+        this.log.info(`Registering new group "${deviceDisplayName}" with HomeKit`);
+        const accessory = new this.api.platformAccessory(deviceDisplayName, uuid);
+        accessory.context.device = deviceDetailsModel;
+        new SonosPlatformAccessory(this, accessory, this.expressDetails);
+
+        this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+    }
+
+    async registerDiscoveredHomeTheater(coordinatorDevice: Device, group: Group) {
+        let description = await coordinatorDevice.deviceDescription();
+        let displayNameUpperCase = description.displayName.toUpperCase();
+        let IsSoundBar = SOUNDBAR_NAMES.includes(displayNameUpperCase);
+
+        if (this.config.soundbarsOnly && !IsSoundBar && !group.Name.includes('Home Theater')) {
+            this.log.debug(`Skipping non-soundbar home theater: ${group.Name}`);
+            return;
+        }
+
+        // Special name for home theater
+        const roomName = group.Name.replace(' Home Theater', '');
+        const groupName = group.Name;
+        this.log.info(`Creating home theater accessory: "${groupName}"`);
+
+        // List the components of the home theater setup
+        this.log.info('Home theater components:');
+        group.ZoneGroupMember.forEach((member, i) => {
+            const isCoord = member.UUID.includes(group.Coordinator) ? ' (coordinator)' : '';
+            const role = this.getDeviceRole(member.Configuration || '');
+            this.log.info(`  ${i + 1}. ${member.ZoneName}${isCoord} ${role}`);
+        });
+
+        // Use configured preference for display name
+        let deviceDisplayName = this.config.roomNameAsName ? groupName : groupName;
+
+        // Create a unique ID for the home theater group
+        const uuid = this.api.hap.uuid.generate(`${description.MACAddress}:${group.ID}:${BREAKING_CHANGE_PACKAGE_VERSION}`);
+        this.foundDevices.push({ uuid: uuid, name: deviceDisplayName });
+
+        this.log.debug(`HomeKit accessory - UUID: ${uuid}, Name: "${deviceDisplayName}"`);
+        this.log.debug(`Home theater hardware: ${description.modelName} (${description.displayName})`);
+
+        const existingAccessory = this.accessories.find((accessory) => accessory.UUID === uuid);
+
+        const deviceDetailsModel = {
+            UUID: uuid,
+            Host: coordinatorDevice.host,
+            IsSoundBar: true,
+            Manufacturer: description.manufacturer,
+            SerialNumber: description.serialNum,
+            ModelName: description.modelName,
+            FirmwareVersion: description.softwareVersion,
+            RoomName: roomName,
+            DisplayName: deviceDisplayName,
+            ExpressAppPort: this.expressAppPort,
+            AudioInputVolumes: [],
+            UpdateAudioVolumes: this.updateInputVolumeLevels.bind(this),
+            // Group-related info
+            IsGroup: true,
+            IsHomeTheater: true,
+            GroupID: group.ID,
+            GroupName: groupName,
+            GroupMembers: group.ZoneGroupMember.map((m) => m.ZoneName)
+        } as DeviceDetails;
+
+        if (existingAccessory) {
+            this.log.info(`Updating home theater "${deviceDisplayName}" from cache`);
+            existingAccessory.displayName = deviceDisplayName;
+            deviceDetailsModel.AudioInputVolumes = existingAccessory.context.device.AudioInputVolumes;
+            existingAccessory.context.device = deviceDetailsModel;
+            new SonosPlatformAccessory(this, existingAccessory, this.expressDetails);
+
+            this.api.updatePlatformAccessories([existingAccessory]);
+            return;
+        }
+
+        this.log.info(`Registering new home theater "${deviceDisplayName}" with HomeKit`);
         const accessory = new this.api.platformAccessory(deviceDisplayName, uuid);
         accessory.context.device = deviceDetailsModel;
         new SonosPlatformAccessory(this, accessory, this.expressDetails);
@@ -222,5 +701,20 @@ export class SonosPlatform implements DynamicPlatformPlugin {
         this.log.debug(`Saving Audio Details ${JSON.stringify(currentSettings)}`);
 
         this.api.updatePlatformAccessories([existingAccessory]);
+    }
+
+    // Helper function to interpret device configuration strings
+    private getDeviceRole(configuration: string): string {
+        if (!configuration) return '';
+
+        const role: string[] = [];
+        if (configuration.includes('HT')) role.push('HOME THEATER');
+        if (configuration.includes('SATELLITES')) role.push('SATELLITE');
+        if (configuration.includes('SUB') || configuration.includes('SUBWOOFER')) role.push('SUBWOOFER');
+        if (configuration.includes('LEFT')) role.push('LEFT');
+        if (configuration.includes('RIGHT')) role.push('RIGHT');
+        if (configuration.includes('BONDED')) role.push('BONDED');
+
+        return role.length ? `[${role.join(', ')}]` : '';
     }
 }

--- a/src/services/volumeControls.ts
+++ b/src/services/volumeControls.ts
@@ -1,5 +1,4 @@
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { RotationSpeed, Brightness } from 'hap-nodejs/dist/lib/definitions/CharacteristicDefinitions';
 import { SonosPlatform } from '../platform';
 import { SonosDeviceManager } from '../helpers/sonosDeviceManager';
 import { ServiceNames, VolumeOptions, DeviceEvents } from '../models/enums';
@@ -9,7 +8,7 @@ export class VolumeControlService {
     private readonly device: SonosDeviceManager;
     private service!: Service;
     private name: string = ServiceNames.VolumeService;
-    private volumeCharacteristic!: typeof RotationSpeed | typeof Brightness;
+    private volumeCharacteristic: any;
 
     constructor(
         private readonly platform: SonosPlatform,
@@ -46,7 +45,7 @@ export class VolumeControlService {
 
         this.service.getCharacteristic(this.platform.Characteristic.On).onGet(this.handleMuteGet.bind(this)).onSet(this.handleMuteSet.bind(this));
 
-        this.service.getCharacteristic(this.volumeCharacteristic!).onSet(this.handleVolumeSet.bind(this));
+        this.service.getCharacteristic(this.volumeCharacteristic).onSet(this.handleVolumeSet.bind(this));
 
         this.device.on(DeviceEvents.DeviceVolumeUpdate, (volume: number) => {
             this.updateCharacteristic(volume);
@@ -95,6 +94,6 @@ export class VolumeControlService {
     }
 
     private updateCharacteristic(volume: number) {
-        this.service!.updateCharacteristic(this.volumeCharacteristic!, volume);
+        this.service!.updateCharacteristic(this.volumeCharacteristic, volume);
     }
 }


### PR DESCRIPTION
Thanks for your work on this plugin, exactly what I was looking for. 

## Motivation

The plugin previously had limitations in how it handled Sonos speaker groups:

1. **Stereo Pair Detection**: The plugin did not properly identify stereo pairs as a single logical device, causing them to appear as separate entities in HomeKit
2. **Group Identification**: When speakers were grouped, there was no consistent way to identify or control the entire group as a single entity
3. **Configuration Options**: Users had no way to choose whether they wanted to see individual speakers, groups, or both in HomeKit

## Changes

- Added two new configuration options:
  - **Group Discovery Mode**: Controls which devices appear in HomeKit
    - Auto (default): Smart detection that only shows multi-device groups
    - Individual Devices Only: Shows only standalone speakers
    - Groups Only: Shows only grouped speakers
    - Both: Shows all individual devices and their groups

  - **Group Naming Format**: Controls how groups are named
    - Coordinator + Count: "Living Room +2" (default)
    - Members List: "Living Room, Kitchen, Office"
    - Simple: "Sonos Group (Living Room)"

- Improved group detection logic to better handle stereo pairs and multi-room groups
- Enhanced the device details model with additional group information
- Updated the README with documentation for the new options

These changes give users more control over their Sonos ecosystem in HomeKit, reducing interface clutter and providing clearer control over grouped speakers.
